### PR TITLE
Encode path parameters with URL escaping

### DIFF
--- a/lib/purple/path.rb
+++ b/lib/purple/path.rb
@@ -5,6 +5,7 @@ require 'faraday'
 require 'active_support/core_ext/hash/deep_merge'
 require 'active_support/core_ext/object/inclusion'
 require 'active_support/core_ext/object/blank'
+require 'cgi'
 
 module Purple
   class Path
@@ -20,7 +21,12 @@ module Purple
     option :responses, optional: true, default: -> { [] }
 
     def full_path
-      current_path = is_param ? @param_value : name
+      current_path = if is_param
+                       CGI.escape(@param_value.to_s)
+                     else
+                       name
+                     end
+
       parent.nil? ? current_path : "#{parent.full_path}/#{current_path}"
     end
 

--- a/spec/purple/client_spec.rb
+++ b/spec/purple/client_spec.rb
@@ -193,6 +193,17 @@ RSpec.describe Unipile::Linkedin::PurpleClient do
 
       expect(result).to eq(:not_found)
     end
+
+    it 'encodes special characters in user_id' do
+      encoded_url = 'https://api4.unipile.com:13451/api/v1/users/%E2%9A%A1%EF%B8%8Fdenis-cooperman-a82021201'
+      response = instance_double(Faraday::Response, status: 404, body: {}.to_json)
+
+      expect(connection).to receive(:get).with(encoded_url, { account_id: 8 }).and_return(response)
+
+      result = described_class.get_user('⚡️denis-cooperman-a82021201', account_id: 8, resource: resource)
+
+      expect(result).to eq(:not_found)
+    end
   end
 end
 


### PR DESCRIPTION
## Summary
- ensure path parameters are URL-escaped so special characters like emoji are handled
- cover emoji user IDs in a new spec

## Testing
- `bundle exec rspec` *(fails: bundler: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_68c81456b484832a9431d6d47601133e